### PR TITLE
feat: Add OIDC provider AWS CDK stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-![Python Template - Hello World Banner](https://raw.githubusercontent.com/linz/template-python-hello-world/master/docs/_static/banner.png)
-
-### _A minimal template for Python development_
+# OIDC Provider
 
 [![GitHub Actions Status](https://github.com/linz/template-python-hello-world/workflows/Build/badge.svg)](https://github.com/linz/template-python-hello-world/actions)
 [![Alerts](https://badgen.net/lgtm/alerts/g/linz/template-python-hello-world?labelColor=2e3a44&label=Alerts&color=3dc64b)](https://lgtm.com/projects/g/linz/template-python-hello-world/context:python)
@@ -15,200 +13,31 @@
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 [![Code Style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
-## Why?
+**OIDC** (OpenID Connect) can be used within _GitHub workflows_ to authenticate with Amazon Web Services. This eliminates the need to store AWS credentials as long-lived GitHub secrets.
 
-This repository exists to show a working example of Python formatting, linting and import sorting configurations with continuous integration.
+This CDK stack enables OpenID Connect in Amazon Web Services. It only needs to be deployed once per AWS account and can be accessed by one or more GitHub repositories. Restrictions can be put in place based on a specific repo, event, branch, or tag. Please refer to GitHub documentation on [Configuring OpenID Connect in Amazon Web Services](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services) for further information.
 
-## Structure
+A single AWS role is created as part of this stack. The role arn is provided as an output of this cdk and will be displayed post deployment. This should be referenced within GitHub workflows (i.e. in your application stack) to manage deployment. The role policy should specify which AWS resources GitHub actions has access to.
 
-This is a very simple, single Python module. It is not a Python package and does not contain the structure or tooling required for packaging / installing a Python project.
+### Prerequisites
 
-## Formatting
+- An AWS account
+- A role policy which specifies the level of access GitHub actions has on AWS (referencing existing AWS managed policy is allowed)
+- A GitHub repo with predetermined access restrictions (i.e. with reference matching a specific branch, event or tag)
 
-Formatting is handled by `black`.
+It is important to prevent untrusted workflows or repositories from requesting access token to AWS resources. Please refer to GitHub documentation on [security hardening with OpenID Connect](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect) for further information.
 
-Black is an uncompromising Python code formatting tool. It takes a Python file as an input, and provides a reformatted Python file as an output, using rules that are a strict subset of [PEP 8](https://www.python.org/dev/peps/pep-0008/). It offers very little in the way of configuration (line length being the main exception) in order to achieve formatting consistency. It is deterministic - it will always produce the same output from the same inputs.
+### How to Deploy
 
-The line length configuration is stored in `pyproject.toml`.
+This cdk stack can be deployed by running the following:  
+`cdk deploy --profile <profile-name> --GithubRepo=<github-repo> --EnvName=<environment-name>`
 
-Configuring Black to automatically run every time code is modified allows developers to forget about _how_ code should be formatted and stay focused on functionality. Many IDEs and text editors allow this. Git hooks can also be used to execute Black before Python code is committed to a repository - this is not configured here as use of autosave and continuous integration checks makes it redundant.
+where
 
-### VSCode Configuration
+- `<profile-name>` references the [named profile for the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
+- `<github-repo>` references the GitHub repository that should be granted access to oidc
+- `<environment-name>` references to the application environment of your deployment  
+  This is used as part of the role creation name (e.g. `arn:aws:iam::123456789:role/<environment-name>Oidc`) and is mostly useful in identifying which account the role belongs to in a multi account setup.
 
-In VSCode, you can set the default Python formatter using the setting: `"python.formatting.provider": "black"`, and then turn on autosave using `"editor.formatOnSave": true`. VSCode will pick up the line length configuration from a `pyproject.toml` file per repository.
-
-## Linting
-
-Linting is handled by `pylint`.
-
-Pylint checks Python files in order to detect syntax errors and potential bugs (unreachable code / unused variables), provide refactoring help,
-
-The configuration is stored in `pyproject.toml`.
-
-### VSCode Configuration
-
-Pylint is enabled by default in VSCode. VSCode will respect Pylint configurations stored in a `pyproject.toml` file per repository.
-
-## Sorting Imports
-
-Import sorting is handled by `isort`.
-
-isort sorts Python imports alphabetically within their respective sections:
-
-1. Standard library imports
-2. Related third party imports
-3. Local application / library specific imports
-
-isort has many configuration options but these can cause inconsistencies with Black, so must be carefully assessed. The configurations within this repository will provide consistently ordered / formatted imports.
-
-The configuration is stored in `pyproject.toml`.
-
-### VSCode Configuration
-
-It is possible to configure VSCode to run `isort` every time you save, using the `codeActionsOnSave": { "source.organizeImports": true }` setting. This currently causes a race condition when formatting by `black` is also configured to occur on save (`"editor.formatOnSave": true`), leading to lines being erroneously deleted. The VSCode Python team [can't do anything](https://github.com/Microsoft/vscode-python/issues/2301) about this.
-
-The configuration stored here works with `black` - that is to say, `black` will not reformat changes made by `isort` - but it is still unsafe to apply both commands simultaneously.
-
-In VSCode, you can manually trigger import sorting by:
-
-- right clicking anywhere within a file and selecting `Sort Imports`.
-- command palette (`Ctrl + Shift + P`), then `Python Refactor: Sort Imports`.
-- creating a shortcut key for `python.sortImports`
-
-There is also some discussion over [whether black should just handle import sorting itself](https://github.com/psf/black/issues/333).
-
-## Line Length
-
-Line length needs to be consistently configured for formatting, linting and while sorting imports. In order to change the line length for a specific project, it will need to be updated in `pyproject.toml`.
-
-## Commit Messages
-
-Commit messages must conform to [conventional commits](https://www.conventionalcommits.org/):
-
-```
-type(optional-scope): description
-```
-
-where type is one of `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test` as specified in `.gitlint`.
-
-For example:
-
-```
-ci(github-actions): add new matrix jobs for Python 3.8
-```
-
-## Continuous Integration
-
-### GitHub Actions
-
-The GitHub Actions workflow is stored at `.github/workflows/push.yml`.
-
-This configuration contains two jobs, with each containing a build matrix with two different versions of Python. The second job depends on the first job being completed successfully by using the `needs` key within the second job.
-
-#### Linter
-
-The first job, `linter`, tests formatting, linting and correct sorting of imports.
-
-```bash
-gitlint
-```
-
-This command runs `gitlint` on the **most recent commit**, to check that commit message titles conform to the conventional commits specification. Earlier commits may not conform, but all commits that are included in a Pull Request are checked by the next command. Pull Requests are the recommended code review workflow before merging into master.
-
-```bash
-gitlint --commits origin/${{ github.base_ref }}..${{ github.event.pull_request.head.sha }}
-```
-
-This command runs `gitlint` over **all commits** in a Pull Request, to check that commit message titles conform to the conventional commits specification.
-
-```bash
-black . --check --diff
-```
-
-This command runs the `black` formatter over the Python files in the current directory. The `--check` flag ensures that the command will error out if any changes are required, rather than making changes. `--diff` will show the difference.
-
-`black` will respect the line length configuration stored in `pyproject.toml`.
-
-```bash
-pylint salutation.py test_salutation.py
-```
-
-This command runs the `pylint` checks for errors, bugs, non-conforming code style and potential code structure improvements over our Python module and tests.
-
-`pylint` uses the configurations stored in `pyproject.toml`.
-
-```bash
-isort -rc . --check --diff
-```
-
-This command runs the `isort` import sorter recursively over the Python files in the current directory. The `--check` flag ensures that the command will error out if any changes are required, rather than making changes. `--diff` will show the difference.
-
-`isort` will respect the configurations stored in `pyproject.toml`.
-
-#### Test
-
-The second job, `test`, runs tests using `pytest` and verifies test coverage.
-
-```bash
-pytest
-```
-
-Simply execute `pytest` and it will [find things that look like tests](http://doc.pytest.org/en/latest/goodpractices.html#conventions-for-python-test-discovery) and run them.
-
-Tests run in a random order thanks to [pytest-randomly](https://pypi.org/project/pytest-randomly/). This helps to detect interdependencies between tests. A test sequence can be reproduced by using the same `--randomly-seed=VALUE` option. `pytest` will always print this value, for example:
-
-> Using --randomly-seed=1548714831
-
-This randomness can also be used to generate fuzzing input.
-
-## Automated Pull Request Merging
-
-### Kodiak
-
-Kodiak is enabled on this repository, configured by `.kodiak.toml`.
-
-Kodiak is a GitHub Bot that automatically merges pull requests that have been labelled `automerge :rocket:` once CI and required approvals have passed. Kodiak is free for open source repositories, but requires a per user subscription for private repositories.
-
-## Automated Dependency Updates
-
-### Dependabot
-
-Dependabot is enabled on this repository, configured by `.github/dependabot.yml`.
-
-Dependabot checks the dependencies listed in `requirements-dev.txt` daily to check if any new versions of those dependencies have been released. If Dependabot finds a new release, it opens a new Pull Request with a version bump, and attempts to show the changelog for that change. It also provides a compatibility prediction based on all of the Pull Requests that it has opened on other open source repositories and whether continous integration was successful.
-
-Dependabot is owned by GitHub and free for both open source and private repositories.
-
-## Automated Vulnerability Checks
-
-### LGTM
-
-LGTM is enabled on this repository. There is no special configuration here, and enabling LGTM occurs at the GitHub organisation level.
-
-LGTM provides automated code review and security analysis.
-
-LGTM is owned by GitHub and free for open source repositories. It can only be enabled on private repositories by building your own instance of LGTM.
-
-## Development
-
-Prerequisites:
-
-- Python 3.6 through 3.9 (this can be changed in `.python-version` and `pyproject.toml`)
-- [Poetry](https://python-poetry.org/docs/#installation)
-
-Optional dependencies:
-
-- [Pyenv](https://github.com/pyenv/pyenv) to use the reference Python version in `pyproject.toml` with a simple `pyenv install`
-
-Install the project dependencies:
-
-```bash
-poetry install
-```
-
-Install commit-msg git hook. It runs on every local commit to check if the commit message conforms to the convention specified in `.gitlint`
-
-```bash
-pre-commit install --hook-type commit-msg --overwrite
-pre-commit install --hook-type=pre-commit --overwrite
-```
+for example:  
+`cdk deploy --profile=li-geostore-ci --parameters=EnvName="Ci" --parameters=GithubRepo="linz/geostore:*"`

--- a/app.py
+++ b/app.py
@@ -1,0 +1,61 @@
+"""
+CDK application entry point file.
+"""
+import constructs
+from aws_cdk import App, CfnOutput, CfnParameter, Stack, aws_iam
+
+
+class OidcProviderStack(Stack):
+    def __init__(self, scope: constructs.Construct, construct_id: str) -> None:
+        super().__init__(scope, construct_id)
+
+        env_name = CfnParameter(self, "EnvName", type="String", description="The environment to deploy the OidcProviderStack")
+
+        github_repo = CfnParameter(
+            self,
+            "GithubRepo",
+            type="String",
+            description="Specify the parameters that limit which GitHub repo has access to AWS",
+        )
+
+        aws_iam.OpenIdConnectProvider(
+            self,
+            "GithubAwsOidcProvider",
+            url="https://token.actions.githubusercontent.com",
+            client_ids=["sts.amazonaws.com"],
+        )
+
+        account_id = aws_iam.AccountRootPrincipal().account_id
+
+        oidc_deploy_role = aws_iam.Role(
+            self,
+            "OidcDeployRole",
+            role_name=f"{env_name.value_as_string}Oidc",
+            assumed_by=aws_iam.WebIdentityPrincipal(
+                f"arn:aws:iam::{account_id}:oidc-provider/token.actions.githubusercontent.com",
+                {
+                    "StringLike": {
+                        "token.actions.githubusercontent.com:aud": ["sts.amazonaws.com"],
+                        "token.actions.githubusercontent.com:sub": [f"repo:{github_repo.value_as_string}"],
+                    }
+                },
+            ),
+        )
+
+        oidc_deploy_role.add_managed_policy(aws_iam.ManagedPolicy.from_aws_managed_policy_name("AdministratorAccess"))
+
+        # Set Cfn to output deploy_role arn post CDK deployment.
+        # Assign or update this value in AWS_ASSUME_ROLE in GitHub secrets
+        CfnOutput(self, "ServiceAccountIamRole", value=oidc_deploy_role.role_arn)
+
+
+def main() -> None:
+    app = App()
+
+    OidcProviderStack(app, "OidcProviderStack")
+
+    app.synth()
+
+
+if __name__ == "__main__":
+    main()

--- a/cdk.json
+++ b/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "python3 app.py"
+}


### PR DESCRIPTION
This CDK stack creates an OpenId Connect provider as well as an IAM role for deployment (oidc_deploy_role). It takes two parameters:
- env_name (refers to the application environment or AWS account name)
- github_repo (references the GitHub repository that should be granted access to oidc)

The stack outputs a role arn which should be referenced within GitHub workflows (i.e. the application stack).