### PR TITLE
feat: Auto-merge Dependabot pull requests

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -7,6 +7,9 @@ auto_approve_usernames = ["dependabot"]
 method = "squash"
 automerge_label = "automerge 🚀"
 
+[merge.automerge_dependencies]
+usernames = ["dependabot"]
+
 [merge.message]
 title = "pull_request_title"
 include_coauthors = true


### PR DESCRIPTION
Results in much less time wasted on manually dealing with Dependabot PRs, at the risk of merging some breaking change if it's not detected by our pipeline. It would be easy to revert, though, if any breaking change is detected after the fact.