### PR TITLE
fix: Use new environment variable syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,22 +16,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - id: python-version
-        run: echo "::set-output name=id::$(cat .python-version)"
+      - name: Get Python version
+        run: echo "python_version=$(cat .python-version)" >> "$GITHUB_ENV"
 
       - name: Setup Python ${{ matrix.python }}
         uses: actions/setup-python@v4.5.0
         with:
-          python-version: ${{ steps.python-version.outputs.id }}
+          python-version: ${{ env.python_version }}
 
       - uses: actions/cache@v3.2.6
         with:
           path: ~/.cache/pip
           key:
-            ${{ runner.os }}-pip-${{ secrets.CACHE_SEED }}-${{ steps.python-version.outputs.id
-            }}-${{ hashFiles('./poetry.lock') }}
-          restore-keys:
-            ${{ runner.os }}-pip-${{ secrets.CACHE_SEED }}-${{ steps.python-version.outputs.id }}-
+            ${{ runner.os }}-pip-${{ secrets.CACHE_SEED }}-${{ env.python_version }}-${{
+            hashFiles('./poetry.lock') }}
+          restore-keys: ${{ runner.os }}-pip-${{ secrets.CACHE_SEED }}-${{ env.python_version }}-
 
       - name: Upgrade pip
         run: python -m pip install --upgrade pip


### PR DESCRIPTION
See
<https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/> and
<https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files>.