### PR TITLE
build: Put virtualenv in global Poetry cache directory

### DIFF
--- a/poetry.toml
+++ b/poetry.toml
@@ -1,2 +1,0 @@
-[virtualenvs]
-in-project = true


### PR DESCRIPTION
Should cut down the CodeQL runtime from over 20 minutes to less than a minute.